### PR TITLE
fix profile plugin version issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.sonatype.oss</groupId>
-		<artifactId>oss-parent</artifactId>
-		<version>9</version>
-	</parent>
-
 	<groupId>org.jpmml</groupId>
 	<artifactId>jpmml-parent</artifactId>
 	<version>1.0-SNAPSHOT</version>
@@ -36,7 +30,7 @@
 	</issueManagement>
 
 	<properties>
-		<java.version>11</java.version>
+		<maven.compiler.release>11</maven.compiler.release>
 		<project.build.outputTimestamp>2025-02-21T10:47:15Z</project.build.outputTimestamp>
 	</properties>
 
@@ -73,7 +67,6 @@
 					<configuration>
 						<showDeprecation>true</showDeprecation>
 						<showWarnings>true</showWarnings>
-						<release>${java.version}</release>
 					</configuration>
 				</plugin>
 				<plugin>
@@ -94,7 +87,7 @@
 							<configuration>
 								<rules>
 									<requireJavaVersion>
-										<version>[${java.version},)</version>
+										<version>[${maven.compiler.release},)</version>
 									</requireJavaVersion>
 									<requireMavenVersion>
 										<version>[3.6.3,)</version>
@@ -114,7 +107,6 @@
 					<artifactId>maven-javadoc-plugin</artifactId>
 					<version>3.11.2</version>
 					<configuration>
-						<release>${java.version}</release>
 						<show>public</show>
 					</configuration>
 				</plugin>
@@ -126,6 +118,9 @@
 						<autoVersionSubmodules>true</autoVersionSubmodules>
 						<localCheckout>true</localCheckout>
 						<pushChanges>false</pushChanges>
+						<mavenExecutorId>forked-path</mavenExecutorId>
+						<useReleaseProfile>false</useReleaseProfile>
+						<arguments>${arguments} -Psonatype-oss-release</arguments>
 					</configuration>
 				</plugin>
 				<plugin>
@@ -213,44 +208,19 @@
 						</execution>
 					</executions>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-gpg-plugin</artifactId>
+					<version>3.2.7</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-release-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>versions-maven-plugin</artifactId>
-			</plugin>
-
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
@@ -258,7 +228,6 @@
 		</plugins>
 	</build>
 
-	<!-- See org.sonatype.oss:oss-parent:9 -->
 	<repositories>
 		<repository>
 			<id>sonatype-nexus-snapshots</id>
@@ -273,4 +242,63 @@
 			</snapshots>
 		</repository>
 	</repositories>
+	<distributionManagement>
+		<snapshotRepository>
+			<id>sonatype-nexus-snapshots</id>
+			<name>Sonatype Nexus Snapshots</name>
+			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+		</snapshotRepository>
+		<repository>
+			<id>sonatype-nexus-staging</id>
+			<name>Nexus Release Repository</name>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+		</repository>
+	</distributionManagement>
+
+	<profiles>
+		<profile>
+			<id>sonatype-oss-release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>attach-sources</id>
+								<goals>
+									<goal>jar-no-fork</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>attach-javadocs</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
issue: `sonatype-oss-release` profile overrides source and javadoc plugin versions, then force old version (non-reproducible...)

proof:
```
$ mvn buildplan:list -Psonatype-oss-release artifact:check-buildplan
...
[INFO] --- buildplan:2.2.2:list (default-cli) @ jpmml-parent ---
[WARNING] Parameter 'release' is unknown for plugin 'maven-javadoc-plugin:2.7:jar (attach-javadocs)'
[INFO] Build Plan for JPMML-Parent: 
------------------------------------------------------------------------------
PHASE      | PLUGIN                | VERSION | GOAL          | EXECUTION ID   
------------------------------------------------------------------------------
validate   | maven-enforcer-plugin | 1.2     | enforce       | enforce-maven  
initialize | jacoco-maven-plugin   | 0.8.12  | prepare-agent | pre-unit-test  
verify     | jacoco-maven-plugin   | 0.8.12  | report        | post-unit-test 
package    | maven-source-plugin   | 2.1.2   | jar-no-fork   | attach-sources 
package    | maven-javadoc-plugin  | 2.7     | jar           | attach-javadocs
verify     | maven-gpg-plugin      | 1.1     | sign          | sign-artifacts 
install    | maven-install-plugin  | 3.1.2   | install       | default-install
deploy     | maven-deploy-plugin   | 3.1.2   | deploy        | default-deploy 
...
```

I don't really get if it's a Maven feature (let override plugin version even if defined at pluginManagement level) or not

but fix is to finally stop using the parent and just copy the few interesting lines

while at it, I renamed custom `java.version` property to standard `maven.compiler.release`, as the standard property name is automatically picked by every plugin without requiring any additional config